### PR TITLE
fix(version parsing) : more lenient on formatting

### DIFF
--- a/src/main/java/org/mortbay/jetty/alpn/agent/JavaVersion.java
+++ b/src/main/java/org/mortbay/jetty/alpn/agent/JavaVersion.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 final class JavaVersion {
 
     private static final Pattern VERSION_PATTERN =
-            Pattern.compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:_([0-9]+)?)(?:-([a-zA-Z]+))?$");
+            Pattern.compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:_([0-9]+))?(?:-.+)?$");
 
     private static final int major;
     private static final int minor;

--- a/src/main/java/org/mortbay/jetty/alpn/agent/JavaVersion.java
+++ b/src/main/java/org/mortbay/jetty/alpn/agent/JavaVersion.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 final class JavaVersion {
 
     private static final Pattern VERSION_PATTERN =
-            Pattern.compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:_([0-9]+)?)$");
+            Pattern.compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:_([0-9]+)?)(?:-([a-zA-Z]+))?$");
 
     private static final int major;
     private static final int minor;


### PR DESCRIPTION
"Official" docker images presents java version under the form x.y.z_k-internal, which fails java version detection.
By applying this patch, we are going from :

```
$ docker run --rm -it -v $(pwd):/app -w /app java:openjdk-8u72-alpine java -javaagent:/app/target/jetty-alpn-agent-2.0.1-SNAPSHOT.jar -version

[jetty-alpn-agent] Could not parse java.version: 1.8.0_72-internal
[jetty-alpn-agent] Could not find a matching alpn-boot JAR for Java version: 1.8.0_72-internal
openjdk version "1.8.0_72-internal"
OpenJDK Runtime Environment (build 1.8.0_72-internal-alpine-r2-b15)
OpenJDK 64-Bit Server VM (build 25.72-b15, mixed mode)


```

To

```
$ docker run --rm -it -v $(pwd):/app -w /app java:openjdk-8u72-alpine java -javaagent:/app/target/jetty-alpn-agent-2.0.1-SNAPSHOT.jar -version

[jetty-alpn-agent] Using: alpn-boot-8.1.7.v20160121.jar
openjdk version "1.8.0_72-internal"
OpenJDK Runtime Environment (build 1.8.0_72-internal-alpine-r2-b15)
OpenJDK 64-Bit Server VM (build 25.72-b15, mixed mode)

```
